### PR TITLE
出品物の削除機能を編集画面に搭載

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -24,14 +24,11 @@ class ProductsController < ApplicationController
     
   end
 
-  def destroy
-    if @product.destroy 
-      redirect_to root_path, notice: "削除が完了しました"
-    else
-      redirect_to product_path(params[:id]), notice: "権限がありません"
-    end
-  end
 
+  def destroy
+    @product.destroy
+    redirect_to("/")
+  end
   def create
     @product = Product.new(product_params)
     unless @product.save
@@ -93,8 +90,6 @@ private
 
   def set_product
     @product = Product.find(params[:id])
-
-
-
+  end
 end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -26,8 +26,11 @@ class ProductsController < ApplicationController
 
 
   def destroy
-    @product.destroy
-    redirect_to("/")
+    if @product.destroy 
+      redirect_to root_path
+    else
+      render :edit, notice: "削除に失敗しました"
+    end
   end
   def create
     @product = Product.new(product_params)

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -121,8 +121,9 @@
               .Main__right__ThirdContent__Category
                 .Main__right__ThirdContent__Category__Left
                   %p カテゴリー(必須)
+                
                 .Main__right__ThirdContent__Category__Right
-                  = f.text_field :category,placeholder: "10文字以内で入力"
+                  = f.collection_select :category_id, Category.where(ancestry: nil), :id, :name, {prompt: '---'}, {id: 'parent_category'}
               .Main__right__ThirdContent__Brand
                 .Main__right__ThirdContent__Brand__Left
                   %p ブランド（任意）
@@ -168,4 +169,12 @@
           %button{:type => "submit"}
             確認
             %span.glyphicon.glyphicon-arrow-right{"aria-hidden" => "true"}
+        .Bottom
+          %button{:type => "submit"}
+            = link_to '削除', product_path(@product.id), method: :delete
+            %span.glyphicon.glyphicon-arrow-right{"aria-hidden" => "true"}
+          
+
+
+    .aago
       = render "front/under_suzuki"


### PR DESCRIPTION
#What
編集画面に商品削除ボタンを実装

#Why
編集時に削除できたほうが確認もできていいと考えたため